### PR TITLE
Refactor display board

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -1,15 +1,14 @@
 class Board:
     SIZE = 9
-    space = " "
 
     def __init__(self):
-        self.spaces = [Board.space] * 9
+        self.spaces = [None] * Board.SIZE 
 
     def full(self):
-        return not Board.space in self.spaces
+        return not None in self.spaces
 
     def update(self, index, token):
         self.spaces[index] = token
 
     def turn_count(self):
-        return Board.SIZE - self.spaces.count(Board.space)
+        return Board.SIZE - self.spaces.count(None)

--- a/src/board.py
+++ b/src/board.py
@@ -1,25 +1,11 @@
 class Board:
     SIZE = 9
     border = "⊱ –––––– {⋆⌘⋆} –––––– ⊰",
-    divider = "      ---+---+---"
     space = " "
 
     def __init__(self):
         self.spaces = [Board.space] * 9
 
-    def stringify_spaces(self):
-        return [
-            #Board.border,
-            "",
-            f"       {self.spaces[0]} | {self.spaces[1]} | {self.spaces[2]} ",
-            Board.divider,
-            f"       {self.spaces[3]} | {self.spaces[4]} | {self.spaces[5]} ", 
-            Board.divider,
-            f"       {self.spaces[6]} | {self.spaces[7]} | {self.spaces[8]} ",
-            "",
-            #Board.border 
-        ]
-    
     def full(self):
         return not Board.space in self.spaces
 

--- a/src/board.py
+++ b/src/board.py
@@ -1,6 +1,5 @@
 class Board:
     SIZE = 9
-    border = "⊱ –––––– {⋆⌘⋆} –––––– ⊰",
     space = " "
 
     def __init__(self):

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,5 +1,7 @@
 class Cli():
-    
+    board_border = "⊱ –––––– {⋆⌘⋆} –––––– ⊰",
+    board_divider = "      ---+---+---"
+
     def __init__(self, writer=print, reader=input):
         self.writer = writer
         self.reader = reader
@@ -25,3 +27,17 @@ class Cli():
         
     def goodbye(self):
         self.log("You played a great game! See you next time!")
+
+    def display_board(self, board):
+        board = f"""\
+
+       {board.spaces[0]} | {board.spaces[1]} | {board.spaces[2]} 
+{Cli.board_divider}
+       {board.spaces[3]} | {board.spaces[4]} | {board.spaces[5]} 
+{Cli.board_divider}
+       {board.spaces[6]} | {board.spaces[7]} | {board.spaces[8]} 
+\
+"""
+        self.log(board)
+        return board
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,6 +1,4 @@
 class Cli():
-    board_border = "⊱ –––––– {⋆⌘⋆} –––––– ⊰",
-    board_divider = "      ---+---+---"
 
     def __init__(self, writer=print, reader=input):
         self.writer = writer
@@ -29,14 +27,18 @@ class Cli():
         self.log("You played a great game! See you next time!")
 
     def display_board(self, board):
-        board = f"""\
+        border = "⊱ –––––– {⋆⌘⋆} –––––– ⊰"
+        divider = "      ---+---+---"
+        board = f"""
+{border}
 
        {board.spaces[0]} | {board.spaces[1]} | {board.spaces[2]} 
-{Cli.board_divider}
+{divider}
        {board.spaces[3]} | {board.spaces[4]} | {board.spaces[5]} 
-{Cli.board_divider}
+{divider}
        {board.spaces[6]} | {board.spaces[7]} | {board.spaces[8]} 
-\
+
+{border}
 """
         self.log(board)
         return board

--- a/src/cli.py
+++ b/src/cli.py
@@ -29,17 +29,20 @@ class Cli():
     def display_board(self, board):
         border = "⊱ –––––– {⋆⌘⋆} –––––– ⊰"
         divider = "      ---+---+---"
-        board = f"""
+        scrubbed_board = [token if token != None else " " for token in
+                          board.spaces]
+
+        board_string = f"""
 {border}
 
-       {board.spaces[0]} | {board.spaces[1]} | {board.spaces[2]} 
+       {scrubbed_board[0]} | {scrubbed_board[1]} | {scrubbed_board[2]} 
 {divider}
-       {board.spaces[3]} | {board.spaces[4]} | {board.spaces[5]} 
+       {scrubbed_board[3]} | {scrubbed_board[4]} | {scrubbed_board[5]} 
 {divider}
-       {board.spaces[6]} | {board.spaces[7]} | {board.spaces[8]} 
+       {scrubbed_board[6]} | {scrubbed_board[7]} | {scrubbed_board[8]} 
 
 {border}
 """
-        self.log(board)
-        return board
+        self.log(board_string)
+        return board_string
 

--- a/src/game.py
+++ b/src/game.py
@@ -15,7 +15,7 @@ class Game():
         self.play()
 
     def play(self):
-        self.cli.log(self.board.stringify_spaces())
+        self.cli.display_board(self.board)
         while not self.board.full():
             self.turn()
 
@@ -26,7 +26,7 @@ class Game():
         move = self.input_to_index(player_choice)
 
         self.board.update(move, self.current_player().token)
-        self.cli.log(self.board.stringify_spaces())
+        self.cli.display_board(self.board)
        
     def input_to_index(self, user_input):
         return int(user_input) - 1 

--- a/test/board_test.py
+++ b/test/board_test.py
@@ -14,13 +14,13 @@ class BoardTest(unittest.TestCase):
     def test_not_full_board(self):
         board = Board()
 
-        board.spaces = ["X", "O", " ", "O", "X", " ", " ", "O", "X"]
+        board.spaces = ["X", "O", None, "O", "X", None, None, "O", "X"]
 
         self.assertEqual(board.full(), False)
 
     def test_update_board(self):
         board = Board()
-        expected = [" ", "X", " ", " ", " ", " ", " ", " ", " "]
+        expected = [None, "X", None, None, None, None, None, None, None]
 
         board.update(1, "X")
         actual = board.spaces
@@ -30,7 +30,7 @@ class BoardTest(unittest.TestCase):
 
     def test_update_board_2(self):
         board = Board()
-        expected = [" ", " ", " ", " ", " ", "O", " ", " ", " "]
+        expected = [None, None, None, None, None, "O", None, None, None]
 
         board.update(5, "O")
         actual = board.spaces

--- a/test/board_test.py
+++ b/test/board_test.py
@@ -3,39 +3,7 @@ import unittest
 from src.board import Board
 
 class BoardTest(unittest.TestCase):
-    def test_empty_board_to_s(self):
-       board = Board()
-       expected = [ 
-            #"⊱ –––––– {⋆⌘⋆} –––––– ⊰",
-            "",
-            "         |   |   ",
-            "      ---+---+---",
-            "         |   |   ",
-            "      ---+---+---",
-            "         |   |   ",
-            "",
-            #"⊱ –––––– {⋆⌘⋆} –––––– ⊰"
-       ]
-
-       self.assertEqual(expected, board.stringify_spaces())
-
-    def test_board_with_pieces(self):
-        board = Board()
-        board.spaces = ["X", " ", " ", "O", " ", "X", " ", " ", "O"]
-        expected = [
-            #"⊱ –––––– {⋆⌘⋆} –––––– ⊰",
-            "",
-            "       X |   |   ",
-            "      ---+---+---",
-            "       O |   | X ",
-            "      ---+---+---",
-            "         |   | O ",
-            "",
-            #"⊱ –––––– {⋆⌘⋆} –––––– ⊰"
-        ]
-
-        self.assertEqual(expected, board.stringify_spaces())
-
+    
     def test_full_board(self):
         board = Board()
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from unittest.mock import call, Mock
 from src.cli import Cli
+from src.board import Board
 
 class CliTest(unittest.TestCase):
     def test_log_message(self):
@@ -44,3 +45,38 @@ class CliTest(unittest.TestCase):
         
         mock.assert_called_once_with(args)
         self.assertEqual(expected, actual)
+
+    def test_display_empty_board(self):
+       board = Board()
+       cli = Cli()
+
+       expected =  """\
+
+         |   |   
+      ---+---+---
+         |   |   
+      ---+---+---
+         |   |   
+\
+"""
+
+       self.assertEqual(expected, cli.display_board(board))
+
+    def test_display_board_in_progress(self):
+        board = Board()
+        cli = Cli()
+        board.spaces = ["X", " ", " ", "O", " ", "X", " ", " ", "O"]
+       
+        expected = """\
+
+       X |   |   
+      ---+---+---
+       O |   | X 
+      ---+---+---
+         |   | O 
+\
+"""
+
+        self.assertEqual(expected, cli.display_board(board))
+
+

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -47,34 +47,40 @@ class CliTest(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_display_empty_board(self):
-       board = Board()
-       cli = Cli()
+        board = Board()
+        mock = Mock()
+        cli = Cli(mock)
 
-       expected =  """\
+        expected =  """
+⊱ –––––– {⋆⌘⋆} –––––– ⊰
 
          |   |   
       ---+---+---
          |   |   
       ---+---+---
          |   |   
-\
+
+⊱ –––––– {⋆⌘⋆} –––––– ⊰
 """
 
-       self.assertEqual(expected, cli.display_board(board))
+        self.assertEqual(expected, cli.display_board(board))
 
     def test_display_board_in_progress(self):
         board = Board()
-        cli = Cli()
+        mock = Mock()
+        cli = Cli(mock)
         board.spaces = ["X", " ", " ", "O", " ", "X", " ", " ", "O"]
        
-        expected = """\
+        expected = """
+⊱ –––––– {⋆⌘⋆} –––––– ⊰
 
        X |   |   
       ---+---+---
        O |   | X 
       ---+---+---
          |   | O 
-\
+
+⊱ –––––– {⋆⌘⋆} –––––– ⊰
 """
 
         self.assertEqual(expected, cli.display_board(board))


### PR DESCRIPTION
I was not happy with the way I was handling the displaying of the board. It felt clunky and didn't seem to line up with concerns that properly. Due to the fact that displaying things is the job of the cli and providing the data for what should be placed on the board is the job of the board it seemed more appropriate to pass the data to a method in the cli class which proceeds to display the board appropriately. 

This decision was made due to a concern Ian brought up about the board's border variables not really belonging in the board class as well as the workshop I attended yesterday about simple design.